### PR TITLE
Fixed Unnecessary install of markupsafe in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN curl https://www.pgadmin.org/static/packages_pgadmin_org.pub | apt-key add &
 RUN apt install -y pgadmin4-desktop
 
 # Install Python packages with pip
-RUN apt install -y python3-pip && pip install pint && pip install markupsafe==2.0.1
+RUN apt install -y python3-pip && pip install pint
 
 # install Ansible per 
 # https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible-on-ubuntu


### PR DESCRIPTION
Removed the redundant line install markupsafe=2.0.1. This issue is mentioned in issue #27.