### PR TITLE
Create a build agent for CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the develop branch
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: geovanni-bot
           password: ${{ secrets.GHCR_AUTH_TOKEN }}
 
       - name: Build image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           registry: ghcr.io
           username: geovanni-bot
-          password: ${{ secrets.GHCR_AUTH_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image
         uses: docker/build-push-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           registry: ghcr.io
           username: geovanni-bot
-          password: ${{ secrets.GHCR_AUTH_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image
         uses: docker/build-push-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           tag-latest: true
 
       - name: Login to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: geovanni-bot

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           registry: ghcr.io
           username: geovanni-bot
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_AUTH_TOKEN }}
 
       - name: Build image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Resolves #33 

I have created a bot user called geovanni-bot whose credentials we can use as an independent build agent for incoming PRs. This PR will only update the Github Action yml, as all other necessary configuration (setting the Github Action Secret, etc) has been done inside of the repo settings.